### PR TITLE
Bug fix: Sharing post crashes app

### DIFF
--- a/app/src/main/java/net/c306/photopress/AppViewModel.kt
+++ b/app/src/main/java/net/c306/photopress/AppViewModel.kt
@@ -1,6 +1,5 @@
 package net.c306.photopress
 
-import android.app.Application
 import android.content.SharedPreferences
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
@@ -15,13 +14,11 @@ import net.c306.photopress.api.UserDetails
 import net.c306.photopress.utils.AppPrefs
 import net.c306.photopress.utils.AuthPrefs
 import net.c306.photopress.utils.Settings
-import net.c306.photopress.utils.isPackageInstalled
 import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
 internal class AppViewModel @Inject constructor(
-    application: Application,
     private val settings: Settings,
     private val appPrefs: AppPrefs,
     private val authPrefs: AuthPrefs,
@@ -39,9 +36,6 @@ internal class AppViewModel @Inject constructor(
             value = if (!it.displayName.isNullOrBlank()) it.displayName else it.username
         }
     }
-
-    // WordPress app installed
-    val isWordPressAppInstalled = MutableLiveData<Boolean>()
 
     // Logged in status
     private val _isLoggedIn = MutableLiveData<Boolean>()
@@ -91,9 +85,5 @@ internal class AppViewModel @Inject constructor(
 
         authPrefs.observe(observer)
         appPrefs.observe(observer)
-
-        isWordPressAppInstalled.value =
-            application.packageManager.isPackageInstalled("org.wordpress.android") == true
     }
-
 }

--- a/app/src/main/java/net/c306/photopress/ui/newPost/AfterPublishedDialog.kt
+++ b/app/src/main/java/net/c306/photopress/ui/newPost/AfterPublishedDialog.kt
@@ -3,11 +3,9 @@ package net.c306.photopress.ui.newPost
 import android.content.DialogInterface
 import android.os.Bundle
 import android.view.View
-import androidx.core.view.isVisible
 import androidx.fragment.app.activityViewModels
-import androidx.lifecycle.ViewModelProvider
 import dagger.hilt.android.AndroidEntryPoint
-import net.c306.photopress.AppViewModel
+import net.c306.customcomponents.utils.CommonUtils
 import net.c306.photopress.R
 import net.c306.photopress.core.extensions.viewBinding
 import net.c306.photopress.databinding.DialogAfterPublishBinding
@@ -25,26 +23,28 @@ class AfterPublishedDialog : BaseBottomSheetDialogFragment(R.layout.dialog_after
 
         binding.highlightActionTitle.text = viewModel.publishedDialogMessage
 
-        ViewModelProvider(requireActivity()).get(AppViewModel::class.java)
-            .isWordPressAppInstalled
-            .observe(viewLifecycleOwner) {
-                binding.buttonOpenPostInWordpressApp.isVisible = it
-            }
-
         binding.buttonSharePost.setOnClickListener {
-            viewModel.sharePost()
+            viewModel.publishedPost.value?.post?.let { post ->
+                CommonUtils.sendSharingIntent(
+                    context = it.context,
+                    text = post.url,
+                    title = post.title,
+                    applyTitleFix = true,
+                )
+            }
+            dismiss()
         }
 
         binding.buttonCopyPostToClipboard.setOnClickListener {
             viewModel.copyPostToClipboard()
+            dismiss()
         }
 
         binding.buttonOpenPostInBrowser.setOnClickListener {
-            viewModel.openPostExternal()
-        }
-
-        binding.buttonOpenPostInWordpressApp.setOnClickListener {
-            viewModel.openPostInWordPress()
+            viewModel.publishedPost.value?.post?.let { post ->
+                startActivity(CommonUtils.getIntentForUrl(post.url))
+            }
+            dismiss()
         }
     }
 
@@ -52,5 +52,4 @@ class AfterPublishedDialog : BaseBottomSheetDialogFragment(R.layout.dialog_after
         viewModel.newPost()
         super.onDismiss(dialog)
     }
-
 }

--- a/app/src/main/java/net/c306/photopress/ui/newPost/NewPostViewModel.kt
+++ b/app/src/main/java/net/c306/photopress/ui/newPost/NewPostViewModel.kt
@@ -1,7 +1,6 @@
 package net.c306.photopress.ui.newPost
 
 import android.content.Context
-import android.content.Intent
 import android.content.SharedPreferences
 import android.net.Uri
 import android.provider.MediaStore
@@ -632,40 +631,6 @@ internal class NewPostViewModel @Inject constructor(
                 Html.fromHtml(published.post.title, Html.FROM_HTML_MODE_COMPACT)
             )
         }
-
-
-    fun sharePost() {
-        publishedPost.value?.post?.let { post ->
-            CommonUtils.sendSharingIntent(
-                context = applicationContext,
-                title = post.url,
-                text = post.title
-            )
-        }
-    }
-
-
-    fun openPostExternal() {
-        publishedPost.value?.post?.let { post ->
-            applicationContext.startActivity(CommonUtils.getIntentForUrl(post.url))
-        }
-    }
-
-
-    fun openPostInWordPress() {
-        publishedPost.value?.post?.let { post ->
-            applicationContext.startActivity(
-                Intent(
-                    Intent.ACTION_VIEW,
-                    Uri.parse("wordpress://viewpost?blogId=${selectedBlogId.value}&postId=${post.id}")
-                    // Uri.parse("wordpress://post?blogId=${selectedBlogId.value}&postId=${post.id}")
-                    // Uri.parse("https://wordpress.com/post/${selectedBlogId.value}/${post.id}")
-                ).apply {
-                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                }
-            )
-        }
-    }
 
 
     fun copyPostToClipboard() {

--- a/app/src/main/res/layout/dialog_after_publish.xml
+++ b/app/src/main/res/layout/dialog_after_publish.xml
@@ -8,33 +8,27 @@
     android:paddingHorizontal="@dimen/activity_horizontal_margin"
     android:paddingVertical="@dimen/activity_vertical_margin"
     tools:context=".ui.newPost.AfterPublishedDialog">
-    
+
     <TextView
         android:id="@+id/highlight_action_title"
         style="@style/BottomSheetTitle"
         tools:text="@string/post_publish_title_post_published" />
-    
+
     <com.google.android.material.button.MaterialButton
         android:id="@+id/button_share_post"
         style="@style/BottomSheetActionButtons"
         android:text="@string/post_publish_button_share_post"
         app:icon="@drawable/ic_share" />
-    
+
     <com.google.android.material.button.MaterialButton
         android:id="@+id/button_copy_post_to_clipboard"
         style="@style/BottomSheetActionButtons"
         android:text="@string/post_publish_button_copy_post_url"
         app:icon="@drawable/ic_copy" />
-    
+
     <com.google.android.material.button.MaterialButton
         android:id="@+id/button_open_post_in_browser"
         style="@style/BottomSheetActionButtons"
         android:text="@string/post_publish_button_open_post_in_browser"
         app:icon="@drawable/ic_open_external" />
-    
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/button_open_post_in_wordpress_app"
-        style="@style/BottomSheetActionButtons"
-        android:text="@string/post_publish_button_open_in_wordpress_app"
-        app:icon="@drawable/ic_wp" />
 </LinearLayout>


### PR DESCRIPTION
Fixed crash + removed "Open in Wordpress" app option. Wordpress has removed post reading - it now only supports it on Jetpack app.